### PR TITLE
Add `Ansi.strip` to strip ANSI escape sequences

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,8 @@
+### unreleased
+
+* Add `Ansi.strip` to strip ANSI escape sequences part of a string.
+  (#7, @MisterDA)
+
 ### 0.5.0
 
 * Rename to `ansi` (#2, @samoht)

--- a/ansi.opam
+++ b/ansi.opam
@@ -14,6 +14,7 @@ depends: [
   "astring"
   "fmt" {>= "0.8.7"}
   "tyxml"
+  "alcotest" {with-test}
   "odoc" {with-doc}
 ]
 build: [

--- a/dune-project
+++ b/dune-project
@@ -17,4 +17,5 @@
   (ocaml (>= 4.10.0))
   astring
   (fmt (>= 0.8.7))
-  tyxml))
+  tyxml
+  (alcotest :with-test)))

--- a/lib/ansi.ml
+++ b/lib/ansi.ml
@@ -101,3 +101,25 @@ let process t data =
   Buffer.contents output
 
 let css = Style.css
+
+let strip str =
+  let len = String.length str in
+  let buf = Buffer.create len in
+  let rec loop start i =
+    if i = len then (
+      if i - start > 0 then Buffer.add_substring buf str start (i - start);
+      Buffer.contents buf)
+    else
+      match String.unsafe_get str i with
+      | '\027' ->
+         if i - start > 0 then Buffer.add_substring buf str start (i - start);
+         skip (i + 1)
+      | _ -> loop start (i + 1)
+  and skip i =
+    if i = len then Buffer.contents buf
+    else
+      match String.unsafe_get str i with
+      | 'm' -> loop (i + 1) (i + 1)
+      | _ -> skip (i + 1)
+  in
+  loop 0 0

--- a/lib/ansi.mli
+++ b/lib/ansi.mli
@@ -12,3 +12,7 @@ val process : t -> string -> string
 
 val css : string
 (** Some default CSS rules to make the HTML output appear in colour. *)
+
+val strip : string -> string
+(** [strip data] reads in [data] and strips out ANSI sequences. It doesn't remember partial
+    sequences between calls to [strip]. *)

--- a/test/dune
+++ b/test/dune
@@ -1,0 +1,3 @@
+(test
+ (name test)
+ (libraries alcotest ansi))

--- a/test/test.ml
+++ b/test/test.ml
@@ -1,0 +1,24 @@
+let test_strip () =
+  let actual =
+    (String.concat "\n"
+       (List.map Ansi.strip [
+            "\027[34mthe lazy fox\027[39m jumps over the brown dog\027[0m";
+            "the lazy fox \027[34mjumps over\027[39m the brown dog\027[0m";
+            "\027[34mthe lazy fox\027[39m jumps over \027[0mthe brown dog";
+            "\027[34mthe lazy fox \027[39mjumps over\027[0thebrown dog"
+    ]));
+  and expected =
+    {|the lazy fox jumps over the brown dog
+the lazy fox jumps over the brown dog
+the lazy fox jumps over the brown dog
+the lazy fox jumps over|}
+  in
+  Alcotest.(check string) "strip escape sequences" expected actual
+
+let () =
+  let open Alcotest in
+  run "ansi" [
+      "utils", [
+        test_case "Ansi.strip"     `Quick test_strip;
+      ];
+    ]


### PR DESCRIPTION
I'm not sure whether I should create a new parser type to be able to strip incomplete sequences and not mess with the main parser transforming escape sequences to html.

The code is taken from Dune (I've helped there too).