### PR TITLE
Fix range of intermediate bytes

### DIFF
--- a/lib/escape_parser.ml
+++ b/lib/escape_parser.ml
@@ -24,7 +24,7 @@ let is_param_byte c =
 
 let is_im_byte c =
   let c = Char.code c in
-  c land 0xf0 = 0x40
+  c land 0xf0 = 0x20
 
 let is_final_byte c =
   let c = Char.code c in


### PR DESCRIPTION
See §5.4 "Standard ECMA-48: Control Functions for Coded Character Sets"
https://www.ecma-international.org/wp-content/uploads/ECMA-48_5th_edition_june_1991.pdf