### PR TITLE
bug fix: respect reverse attr when default color is active

### DIFF
--- a/lib/ansi.ml
+++ b/lib/ansi.ml
@@ -39,10 +39,12 @@ let name_of_colour : Escape_parser.base_colour -> string = function
   | `White -> "white"
   | `Yellow -> "yellow"
 
-let name_of_colour : Escape_parser.colour -> string option = function
-  | `Default | `Rgb _ -> None
-  | `Hi colour -> Some (name_of_colour colour)
-  | (#Escape_parser.base_colour as colour) -> Some (name_of_colour colour)
+let name_of_colour ~reversed (c : Escape_parser.colour) : string option =
+  match reversed, c with
+  | true, `Default -> Some "reversed-default"
+  | _, (`Default | `Rgb _) -> None
+  | _, `Hi colour -> Some (name_of_colour colour)
+  | _, (#Escape_parser.base_colour as colour) -> Some (name_of_colour colour)
 
 let is_bright : Escape_parser.colour -> bool = function `Hi _ -> true | _ -> false
 
@@ -85,8 +87,8 @@ let with_style s txt =
       let cls = if italic then "italic" :: cls else cls in
       let cls = if underline then "underline" :: cls else cls in
       let cls = if double_underline then "double-underline" :: cls else cls in
-      let cls = cl "fg" (is_bright fg) (name_of_colour fg) @ cls in
-      let cls = cl "bg" (is_bright bg) (name_of_colour bg) @ cls in
+      let cls = cl "fg" (is_bright fg) (name_of_colour ~reversed fg) @ cls in
+      let cls = cl "bg" (is_bright bg) (name_of_colour ~reversed bg) @ cls in
       let style = function
         | (`Rgb x, `Fg) -> [ Printf.sprintf "color: #%06x" x ]
         | (`Rgb x, `Bg) -> [ Printf.sprintf "background-color: #%06x" x ]

--- a/lib/style.ml
+++ b/lib/style.ml
@@ -52,6 +52,13 @@ let pp_dof fmt dof rgb =
     (pp_rgb ~faint:false)
     rgb
 
+let pp_rdof fmt dof rgb =
+  Fmt.pf fmt ".%s-reversed-default { %s: %a }\n"
+    (match dof with `Fg -> "fg" | `Bg -> "bg")
+    (match dof with `Fg -> "color" | `Bg -> "background")
+    (pp_rgb ~faint:false)
+    rgb
+
 let pp fmt (colors, bright_colors, dof) =
   pp_colors fmt `Fg ~bright:false ~faint:false colors;
   pp_colors fmt `Fg ~bright:false ~faint:true colors;
@@ -61,6 +68,8 @@ let pp fmt (colors, bright_colors, dof) =
   pp_colors fmt `Bg ~bright:true ~faint:false bright_colors;
   pp_dof fmt `Fg dof.fg;
   pp_dof fmt `Bg dof.bg;
+  pp_rdof fmt `Fg dof.bg;
+  pp_rdof fmt `Bg dof.fg;
   Fmt.pf fmt
 {|pre span.bold { font-weight: bold }
 pre span.italic { font-weight: italic }

--- a/test/color_24bit.html
+++ b/test/color_24bit.html
@@ -49,6 +49,8 @@ pre span.bg-bright-cyan { background: rgb(0, 255, 255) }
 pre span.bg-bright-white { background: rgb(255, 255, 255) }
 .fg-default { color: rgb(0, 0, 0) }
 .bg-default { background: rgb(255, 255, 255) }
+.fg-reversed-default { color: rgb(255, 255, 255) }
+.bg-reversed-default { background: rgb(0, 0, 0) }
 pre span.bold { font-weight: bold }
 pre span.italic { font-weight: italic }
 pre span.underline { text-decoration: underline }

--- a/test/color_4bit.html
+++ b/test/color_4bit.html
@@ -49,6 +49,8 @@ pre span.bg-bright-cyan { background: rgb(0, 255, 255) }
 pre span.bg-bright-white { background: rgb(255, 255, 255) }
 .fg-default { color: rgb(0, 0, 0) }
 .bg-default { background: rgb(255, 255, 255) }
+.fg-reversed-default { color: rgb(255, 255, 255) }
+.bg-reversed-default { background: rgb(0, 0, 0) }
 pre span.bold { font-weight: bold }
 pre span.italic { font-weight: italic }
 pre span.underline { text-decoration: underline }

--- a/test/color_8bit.html
+++ b/test/color_8bit.html
@@ -49,6 +49,8 @@ pre span.bg-bright-cyan { background: rgb(0, 255, 255) }
 pre span.bg-bright-white { background: rgb(255, 255, 255) }
 .fg-default { color: rgb(0, 0, 0) }
 .bg-default { background: rgb(255, 255, 255) }
+.fg-reversed-default { color: rgb(255, 255, 255) }
+.bg-reversed-default { background: rgb(0, 0, 0) }
 pre span.bold { font-weight: bold }
 pre span.italic { font-weight: italic }
 pre span.underline { text-decoration: underline }

--- a/test/link.html
+++ b/test/link.html
@@ -49,6 +49,8 @@ pre span.bg-bright-cyan { background: rgb(0, 255, 255) }
 pre span.bg-bright-white { background: rgb(255, 255, 255) }
 .fg-default { color: rgb(0, 0, 0) }
 .bg-default { background: rgb(255, 255, 255) }
+.fg-reversed-default { color: rgb(255, 255, 255) }
+.bg-reversed-default { background: rgb(0, 0, 0) }
 pre span.bold { font-weight: bold }
 pre span.italic { font-weight: italic }
 pre span.underline { text-decoration: underline }


### PR DESCRIPTION
It seems that there exists a bug when dealing with the reversed attribute when background and/and foreground color is not explicitly set (thus default).

* before fix: 
  ![Screen Shot 2023-09-16 at 13 39 12](https://github.com/ocurrent/ansi/assets/2413116/a3506e9f-57aa-4958-ab5f-b290cd1e771b)
* after fix: 
  ![Screen Shot 2023-09-16 at 13 38 42](https://github.com/ocurrent/ansi/assets/2413116/0adb4c52-ab61-4bb6-b920-1d0a10a98e9f)

This PR introduce a fix by attaching a `fg-reversed-default` or a `bg-reversed-default` class when the reversed state is true but foreground and/or background color is left as default.