### PR TITLE
update Makefile - correct test target to run `dune build @runtest`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 .PHONY: test build
 
 test:
-	dune build @check
+	dune build @runtest
 
 build:
 	dune build @all


### PR DESCRIPTION
Currently `make test` will run `dune build @check`, which does not run the tests.

This PR change it to run `dune build @runtest` as per Dune's convention.